### PR TITLE
chore: main 브랜치 push 및 PR 시 실행되는 CI 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: 테스트, 빌드
+        run: ./gradlew clean build --no-daemon
+


### PR DESCRIPTION
## 📌 개요
main 브랜치에 push 및 PR 시 자동으로 테스트 및 빌드가 실행되도록 하기 위해 GitHub Actions CI 파이프라인을 설정

## ✅ 변경 사항
- [x] `.github/workflows/ci.yml` 파일 생성
- [x] Java 21 및 Gradle 환경 설정
- [x] 테스트 및 빌드 실행


## 📎 관련 이슈
- closes #2 

