### PR TITLE
feature: 공휴일 검색 기능 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,28 @@ dependencies {
 
 	// Springdoc OpenAPI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/publicholidaysbycountry/config/QueryDslConfig.java
+++ b/src/main/java/com/publicholidaysbycountry/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.publicholidaysbycountry.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/global/Constants.java
+++ b/src/main/java/com/publicholidaysbycountry/global/Constants.java
@@ -5,5 +5,6 @@ public final class Constants {
     public static final String AVAILABLE_COUNTRIES_API_URL = "https://date.nager.at/api/v3/AvailableCountries";
     public static final String PUBLIC_HOLIDAYS_API_URL = "https://date.nager.at/api/v3/PublicHolidays/";
     public static final int YEAR_RANGE = 5;
-
+    public static final int DEFAULT_PAGE = 0;
+    public static final int DEFAULT_SIZE = 10;
 }

--- a/src/main/java/com/publicholidaysbycountry/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/publicholidaysbycountry/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.publicholidaysbycountry.global.exception;
 
 import com.publicholidaysbycountry.global.response.CommonApiResponse;
 import com.publicholidaysbycountry.global.response.code.ResponseCode;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -23,4 +24,9 @@ public class GlobalExceptionHandler {
         return CommonApiResponse.failure(ResponseCode.INVALID_HOLIDAY_TYPE, ex.getMessage());
     }
 
+    @ExceptionHandler(BindException.class)
+    public CommonApiResponse<?> handleBindException(BindException ex) {
+        String message = ex.getBindingResult().getAllErrors().getFirst().getDefaultMessage();
+        return CommonApiResponse.failure(ResponseCode.INVALID_REQUEST, message);
+    }
 }

--- a/src/main/java/com/publicholidaysbycountry/global/response/code/ResponseCode.java
+++ b/src/main/java/com/publicholidaysbycountry/global/response/code/ResponseCode.java
@@ -11,6 +11,7 @@ public enum ResponseCode {
     COUNTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNTRY_NOT_FOUND"),
     HOLIDAY_NOT_FOUND(HttpStatus.NOT_FOUND, "HOLIDAY_NOT_FOUND"),
     INVALID_HOLIDAY_TYPE(HttpStatus.NOT_FOUND, "INVALID_HOLIDAY_TYPE"),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -13,4 +13,6 @@ public interface HolidayRepository {
     List<Holiday> findByYear(List<Integer> year);
 
     List<Holiday> findByCountryCodeIn(List<String> countryCode);
+
+    List<Holiday> findAll();
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -7,4 +7,6 @@ public interface HolidayRepository {
     int save(List<Holiday> holidays);
 
     void deleteAll();
+
+    List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -2,17 +2,19 @@ package com.publicholidaysbycountry.holiday.application;
 
 import com.publicholidaysbycountry.holiday.domain.Holiday;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface HolidayRepository {
     int save(List<Holiday> holidays);
 
     void deleteAll();
 
-    List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode);
+    Page<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode, Pageable pageable);
 
-    List<Holiday> findByYear(List<Integer> year);
+    Page<Holiday> findByYear(List<Integer> year, Pageable pageable);
 
-    List<Holiday> findByCountryCodeIn(List<String> countryCode);
+    Page<Holiday> findByCountryCodeIn(List<String> countryCode, Pageable pageable);
 
-    List<Holiday> findAll();
+    Page<Holiday> findAll(Pageable pageable);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -1,6 +1,7 @@
 package com.publicholidaysbycountry.holiday.application;
 
 import com.publicholidaysbycountry.holiday.domain.Holiday;
+import com.publicholidaysbycountry.holiday.domain.HolidayType;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -19,5 +20,7 @@ public interface HolidayRepository {
 
     Page<Holiday> findAll(Pageable pageable);
 
-    Page<Holiday> findByDateBetween(LocalDate from, LocalDate to, Pageable pageable);
+    Page<Holiday> findAllByFilter(LocalDate from, LocalDate to, List<HolidayType> types, Boolean hasCounty,
+                                  Boolean fixed,
+                                  Boolean global, Integer launchYear, List<String> countryCode, Pageable pageable);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -11,4 +11,6 @@ public interface HolidayRepository {
     List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode);
 
     List<Holiday> findByYear(List<Integer> year);
+
+    List<Holiday> findByCountryCodeIn(List<String> countryCode);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -9,4 +9,6 @@ public interface HolidayRepository {
     void deleteAll();
 
     List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode);
+
+    List<Holiday> findByYear(List<Integer> year);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -1,6 +1,7 @@
 package com.publicholidaysbycountry.holiday.application;
 
 import com.publicholidaysbycountry.holiday.domain.Holiday;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,6 @@ public interface HolidayRepository {
     Page<Holiday> findByCountryCodeIn(List<String> countryCode, Pageable pageable);
 
     Page<Holiday> findAll(Pageable pageable);
+
+    Page<Holiday> findByDateBetween(LocalDate from, LocalDate to, Pageable pageable);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -5,6 +5,7 @@ import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.holiday.application.dto.HolidayDTO;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -64,5 +65,11 @@ public class HolidayService {
     public Page<HolidayResponseDTO> getAllHolidays(Pageable pageable) {
         return holidayRepository.findAll(pageable)
                 .map(HolidayResponseDTO::fromHoliday);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<HolidayResponseDTO> getHolidaysByDate(LocalDate from, LocalDate to, Pageable pageable) {
+        Page<Holiday> holidays = holidayRepository.findByDateBetween(from, to, pageable);
+        return holidays.map(HolidayResponseDTO::fromHoliday);
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -60,6 +60,6 @@ public class HolidayService {
 
     @Transactional(readOnly = true)
     public List<HolidayResponseDTO> getAllHolidays() {
-        return null;
+        return HolidayResponseDTO.fromHolidays(holidayRepository.findAll());
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -8,6 +8,8 @@ import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponse
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,25 +43,26 @@ public class HolidayService {
     }
 
     @Transactional(readOnly = true)
-    public List<HolidayResponseDTO> getHolidaysByYearAndCountry(List<Integer> year, List<String> countryCode) {
-        List<Holiday> holidays = holidayRepository.findByYearAndCountryCode(year, countryCode);
-        return HolidayResponseDTO.fromHolidays(holidays);
+    public Page<HolidayResponseDTO> getHolidaysByYearAndCountry(List<Integer> year, List<String> countryCode, Pageable pageable) {
+        Page<Holiday> holidays = holidayRepository.findByYearAndCountryCode(year, countryCode, pageable);
+        return holidays.map(HolidayResponseDTO::fromHoliday);
     }
 
     @Transactional(readOnly = true)
-    public List<HolidayResponseDTO> getHolidaysByYear(List<Integer> year) {
-        List<Holiday> holidays = holidayRepository.findByYear(year);
-        return HolidayResponseDTO.fromHolidays(holidays);
+    public Page<HolidayResponseDTO> getHolidaysByYear(List<Integer> year, Pageable pageable) {
+        Page<Holiday> holidays = holidayRepository.findByYear(year, pageable);
+        return holidays.map(HolidayResponseDTO::fromHoliday);
     }
 
     @Transactional(readOnly = true)
-    public List<HolidayResponseDTO> getHolidaysByCountry(List<String> countryCode) {
-        List<Holiday> holidays = holidayRepository.findByCountryCodeIn(countryCode);
-        return HolidayResponseDTO.fromHolidays(holidays);
+    public Page<HolidayResponseDTO> getHolidaysByCountry(List<String> countryCode, Pageable pageable) {
+        Page<Holiday> holidays = holidayRepository.findByCountryCodeIn(countryCode, pageable);
+        return holidays.map(HolidayResponseDTO::fromHoliday);
     }
 
     @Transactional(readOnly = true)
-    public List<HolidayResponseDTO> getAllHolidays() {
-        return HolidayResponseDTO.fromHolidays(holidayRepository.findAll());
+    public Page<HolidayResponseDTO> getAllHolidays(Pageable pageable) {
+        return holidayRepository.findAll(pageable)
+                .map(HolidayResponseDTO::fromHoliday);
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -48,7 +48,8 @@ public class HolidayService {
 
     @Transactional(readOnly = true)
     public List<HolidayResponseDTO> getHolidaysByYear(List<Integer> year) {
-        return null;
+        List<Holiday> holidays = holidayRepository.findByYear(year);
+        return HolidayResponseDTO.fromHolidays(holidays);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -4,6 +4,7 @@ import com.publicholidaysbycountry.country.domain.Country;
 import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.holiday.application.dto.HolidayDTO;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
+import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -39,4 +40,24 @@ public class HolidayService {
         return HolidayDTO.toHolidays(holidayDTOs);
     }
 
+    @Transactional(readOnly = true)
+    public List<HolidayResponseDTO> getHolidaysByYearAndCountry(List<Integer> year, List<String> countryCode) {
+        List<Holiday> holidays = holidayRepository.findByYearAndCountryCode(year, countryCode);
+        return HolidayResponseDTO.fromHolidays(holidays);
+    }
+
+    @Transactional(readOnly = true)
+    public List<HolidayResponseDTO> getHolidaysByYear(List<Integer> year) {
+        return null;
+    }
+
+    @Transactional(readOnly = true)
+    public List<HolidayResponseDTO> getHolidaysByCountry(List<String> countryCode) {
+        return null;
+    }
+
+    @Transactional(readOnly = true)
+    public List<HolidayResponseDTO> getAllHolidays() {
+        return null;
+    }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -54,7 +54,8 @@ public class HolidayService {
 
     @Transactional(readOnly = true)
     public List<HolidayResponseDTO> getHolidaysByCountry(List<String> countryCode) {
-        return null;
+        List<Holiday> holidays = holidayRepository.findByCountryCodeIn(countryCode);
+        return HolidayResponseDTO.fromHolidays(holidays);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -9,4 +9,6 @@ public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long>
     Optional<List<HolidayEntity>> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
 
     Optional<List<HolidayEntity>> findByYearIn(List<Integer> year);
+
+    Optional<List<HolidayEntity>> findByCountryCodeIn(List<String> countryCode);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long> {
     Optional<List<HolidayEntity>> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
+
+    Optional<List<HolidayEntity>> findByYearIn(List<Integer> year);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -1,6 +1,7 @@
 package com.publicholidaysbycountry.holiday.infrastructure;
 
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,6 @@ public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long>
     Page<HolidayEntity> findByYearIn(List<Integer> year, Pageable pageable);
 
     Page<HolidayEntity> findByCountryCodeIn(List<String> countryCode, Pageable pageable);
+
+    Page<HolidayEntity> findByDateBetween(LocalDate from, LocalDate to, Pageable pageable);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -2,13 +2,12 @@ package com.publicholidaysbycountry.holiday.infrastructure;
 
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long> {
-    Optional<List<HolidayEntity>> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
+    List<HolidayEntity> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
 
-    Optional<List<HolidayEntity>> findByYearIn(List<Integer> year);
+    List<HolidayEntity> findByYearIn(List<Integer> year);
 
-    Optional<List<HolidayEntity>> findByCountryCodeIn(List<String> countryCode);
+    List<HolidayEntity> findByCountryCodeIn(List<String> countryCode);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -2,12 +2,14 @@ package com.publicholidaysbycountry.holiday.infrastructure;
 
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long> {
-    List<HolidayEntity> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
+    Page<HolidayEntity> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode, Pageable pageable);
 
-    List<HolidayEntity> findByYearIn(List<Integer> year);
+    Page<HolidayEntity> findByYearIn(List<Integer> year, Pageable pageable);
 
-    List<HolidayEntity> findByCountryCodeIn(List<String> countryCode);
+    Page<HolidayEntity> findByCountryCodeIn(List<String> countryCode, Pageable pageable);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayJpaRepository.java
@@ -1,7 +1,10 @@
 package com.publicholidaysbycountry.holiday.infrastructure;
 
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HolidayJpaRepository extends JpaRepository<HolidayEntity, Long> {
+    Optional<List<HolidayEntity>> findByYearInAndCountryCodeIn(List<Integer> year, List<String> countryCode);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayQueryRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayQueryRepository.java
@@ -1,0 +1,84 @@
+package com.publicholidaysbycountry.holiday.infrastructure;
+
+import com.publicholidaysbycountry.holiday.domain.HolidayType;
+import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
+import com.publicholidaysbycountry.holiday.infrastructure.entity.QHolidayCountyEntity;
+import com.publicholidaysbycountry.holiday.infrastructure.entity.QHolidayEntity;
+import com.publicholidaysbycountry.holiday.infrastructure.entity.QHolidayTypeEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HolidayQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<HolidayEntity> findAllByFilter(LocalDate from, LocalDate to, List<HolidayType> types, Boolean hasCounty,
+                                         Boolean fixed, Boolean global, Integer launchYear, List<String> countryCode, Pageable pageable) {
+        QHolidayEntity qHoliday = QHolidayEntity.holidayEntity;
+        QHolidayTypeEntity qType = QHolidayTypeEntity.holidayTypeEntity;
+        QHolidayCountyEntity qCounty = QHolidayCountyEntity.holidayCountyEntity;
+
+        JPQLQuery<HolidayEntity> query = jpaQueryFactory
+                .selectFrom(qHoliday)
+                .distinct()
+                .leftJoin(qHoliday.types, qType)
+                .leftJoin(qHoliday.counties, qCounty);
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (from != null) {
+            builder.and(qHoliday.date.goe(from));
+        }
+        if (to != null) {
+            builder.and(qHoliday.date.loe(to));
+        }
+        if (types != null && !types.isEmpty()) {
+            builder.and(qHoliday.holidayId.in(
+                    JPAExpressions.select(qType.holiday.holidayId)
+                            .from(qType)
+                            .where(qType.type.in(types))
+            ));
+        }
+        if (fixed != null) {
+            builder.and(qHoliday.fixed.eq(fixed));
+        }
+        if (global != null) {
+            builder.and(qHoliday.global.eq(global));
+        }
+        if (launchYear != null) {
+            builder.and(qHoliday.launchYear.eq(launchYear));
+        }
+        if (hasCounty != null) {
+            if (hasCounty) {
+                builder.and(qCounty.countyId.isNotNull());
+            } else {
+                builder.and(qCounty.countyId.isNull());
+            }
+        }
+        if (countryCode != null && !countryCode.isEmpty()) {
+            builder.and(qHoliday.countryCode.in(countryCode));
+        }
+
+        query.where(builder);
+
+        long total = query.fetch().size();
+
+        List<HolidayEntity> results = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -7,6 +7,8 @@ import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayTypeEntity;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -45,31 +47,27 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     }
 
     @Override
-    public List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode);
-
-        return getHolidays(holidayEntities);
+    public Page<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode, Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode, pageable);
+        return holidayEntities.map(HolidayEntity::toHoliday);
     }
 
     @Override
-    public List<Holiday> findByYear(List<Integer> year) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year);
-
-        return getHolidays(holidayEntities);
+    public Page<Holiday> findByYear(List<Integer> year, Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year, pageable);
+        return holidayEntities.map(HolidayEntity::toHoliday);
     }
 
     @Override
-    public List<Holiday> findByCountryCodeIn(List<String> countryCode) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode);
-
-        return getHolidays(holidayEntities);
+    public Page<Holiday> findByCountryCodeIn(List<String> countryCode, Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode, pageable);
+        return holidayEntities.map(HolidayEntity::toHoliday);
     }
 
     @Override
-    public List<Holiday> findAll() {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findAll();
-
-        return getHolidays(holidayEntities);
+    public Page<Holiday> findAll(Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findAll(pageable);
+        return holidayEntities.map(HolidayEntity::toHoliday);
     }
 
     private HolidayEntity saveHoliday(Holiday holiday) {
@@ -89,11 +87,5 @@ public class HolidayRepositoryImpl implements HolidayRepository {
                 .map(type -> new HolidayTypeEntity(savedHolidayEntity.getHolidayId(), type))
                 .toList();
         holidayTypeJpaRepository.saveAll(holidayTypeEntities);
-    }
-
-    private List<Holiday> getHolidays(List<HolidayEntity> holidayEntities) {
-        return holidayEntities.stream()
-                .map(HolidayEntity::toHoliday)
-                .toList();
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.publicholidaysbycountry.holiday.infrastructure;
 
 import com.publicholidaysbycountry.holiday.application.HolidayRepository;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
+import com.publicholidaysbycountry.holiday.domain.HolidayType;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayCountyEntity;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayTypeEntity;
@@ -19,6 +20,7 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     private final HolidayJpaRepository holidayJpaRepository;
     private final HolidayCountyJpaRepository holidayCountyJpaRepository;
     private final HolidayTypeJpaRepository holidayTypeJpaRepository;
+    private final HolidayQueryRepository holidayQueryRepository;
 
     @Override
     public int save(List<Holiday> holidays) {
@@ -49,7 +51,8 @@ public class HolidayRepositoryImpl implements HolidayRepository {
 
     @Override
     public Page<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode, Pageable pageable) {
-        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode, pageable);
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode,
+                pageable);
         return holidayEntities.map(HolidayEntity::toHoliday);
     }
 
@@ -72,8 +75,11 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     }
 
     @Override
-    public Page<Holiday> findByDateBetween(LocalDate from, LocalDate to, Pageable pageable) {
-        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByDateBetween(from, to, pageable);
+    public Page<Holiday> findAllByFilter(LocalDate from, LocalDate to, List<HolidayType> types, Boolean hasCounty,
+                                         Boolean fixed, Boolean global, Integer launchYear, List<String> countryCode,
+                                         Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayQueryRepository.findAllByFilter(from, to, types, hasCounty, fixed,
+                global, launchYear, countryCode, pageable);
         return holidayEntities.map(HolidayEntity::toHoliday);
     }
 

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -84,14 +84,14 @@ public class HolidayRepositoryImpl implements HolidayRepository {
 
     private void saveHolidayCounties(Holiday holiday, HolidayEntity savedHolidayEntity) {
         List<HolidayCountyEntity> countyEntities = holiday.getCounties().stream()
-                .map(countyName -> new HolidayCountyEntity(countyName, savedHolidayEntity.getHolidayId()))
+                .map(countyName -> new HolidayCountyEntity(countyName, savedHolidayEntity))
                 .toList();
         holidayCountyJpaRepository.saveAll(countyEntities);
     }
 
     private void saveHolidayTypes(Holiday holiday, HolidayEntity savedHolidayEntity) {
         List<HolidayTypeEntity> holidayTypeEntities = holiday.getTypes().stream()
-                .map(type -> new HolidayTypeEntity(savedHolidayEntity.getHolidayId(), type))
+                .map(type -> new HolidayTypeEntity(savedHolidayEntity, type))
                 .toList();
         holidayTypeJpaRepository.saveAll(holidayTypeEntities);
     }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -44,6 +44,15 @@ public class HolidayRepositoryImpl implements HolidayRepository {
         holidayJpaRepository.deleteAllInBatch();
     }
 
+    @Override
+    public List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode) {
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode).orElseThrow();
+
+        return holidayEntities.stream()
+                .map(HolidayEntity::toHoliday)
+                .toList();
+    }
+
     private HolidayEntity saveHoliday(Holiday holiday) {
         HolidayEntity holidayEntity = HolidayEntity.fromHoliday(holiday);
         return holidayJpaRepository.save(holidayEntity);

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.publicholidaysbycountry.holiday.domain.Holiday;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayCountyEntity;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayEntity;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayTypeEntity;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -67,6 +68,12 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     @Override
     public Page<Holiday> findAll(Pageable pageable) {
         Page<HolidayEntity> holidayEntities = holidayJpaRepository.findAll(pageable);
+        return holidayEntities.map(HolidayEntity::toHoliday);
+    }
+
+    @Override
+    public Page<Holiday> findByDateBetween(LocalDate from, LocalDate to, Pageable pageable) {
+        Page<HolidayEntity> holidayEntities = holidayJpaRepository.findByDateBetween(from, to, pageable);
         return holidayEntities.map(HolidayEntity::toHoliday);
     }
 

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -62,6 +62,15 @@ public class HolidayRepositoryImpl implements HolidayRepository {
                 .toList();
     }
 
+    @Override
+    public List<Holiday> findByCountryCodeIn(List<String> countryCode) {
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode).orElseThrow();
+
+        return holidayEntities.stream()
+                .map(HolidayEntity::toHoliday)
+                .toList();
+    }
+
     private HolidayEntity saveHoliday(Holiday holiday) {
         HolidayEntity holidayEntity = HolidayEntity.fromHoliday(holiday);
         return holidayJpaRepository.save(holidayEntity);

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -48,27 +48,28 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     public List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode) {
         List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode).orElseThrow();
 
-        return holidayEntities.stream()
-                .map(HolidayEntity::toHoliday)
-                .toList();
+        return getHolidays(holidayEntities);
     }
 
     @Override
     public List<Holiday> findByYear(List<Integer> year) {
         List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year).orElseThrow();
 
-        return holidayEntities.stream()
-                .map(HolidayEntity::toHoliday)
-                .toList();
+        return getHolidays(holidayEntities);
     }
 
     @Override
     public List<Holiday> findByCountryCodeIn(List<String> countryCode) {
         List<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode).orElseThrow();
 
-        return holidayEntities.stream()
-                .map(HolidayEntity::toHoliday)
-                .toList();
+        return getHolidays(holidayEntities);
+    }
+
+    @Override
+    public List<Holiday> findAll() {
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findAll();
+
+        return getHolidays(holidayEntities);
     }
 
     private HolidayEntity saveHoliday(Holiday holiday) {
@@ -88,5 +89,11 @@ public class HolidayRepositoryImpl implements HolidayRepository {
                 .map(type -> new HolidayTypeEntity(savedHolidayEntity.getHolidayId(), type))
                 .toList();
         holidayTypeJpaRepository.saveAll(holidayTypeEntities);
+    }
+
+    private List<Holiday> getHolidays(List<HolidayEntity> holidayEntities) {
+        return holidayEntities.stream()
+                .map(HolidayEntity::toHoliday)
+                .toList();
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -53,6 +53,15 @@ public class HolidayRepositoryImpl implements HolidayRepository {
                 .toList();
     }
 
+    @Override
+    public List<Holiday> findByYear(List<Integer> year) {
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year).orElseThrow();
+
+        return holidayEntities.stream()
+                .map(HolidayEntity::toHoliday)
+                .toList();
+    }
+
     private HolidayEntity saveHoliday(Holiday holiday) {
         HolidayEntity holidayEntity = HolidayEntity.fromHoliday(holiday);
         return holidayJpaRepository.save(holidayEntity);

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -1,8 +1,5 @@
 package com.publicholidaysbycountry.holiday.infrastructure;
 
-import com.publicholidaysbycountry.country.infrastructure.CountryEntity;
-import com.publicholidaysbycountry.country.infrastructure.CountryJpaRepository;
-import com.publicholidaysbycountry.global.exception.CountryNotFoundException;
 import com.publicholidaysbycountry.holiday.application.HolidayRepository;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
 import com.publicholidaysbycountry.holiday.infrastructure.entity.HolidayCountyEntity;
@@ -19,7 +16,6 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     private final HolidayJpaRepository holidayJpaRepository;
     private final HolidayCountyJpaRepository holidayCountyJpaRepository;
     private final HolidayTypeJpaRepository holidayTypeJpaRepository;
-    private final CountryJpaRepository countryJpaRepository;
 
     @Override
     public int save(List<Holiday> holidays) {
@@ -49,18 +45,8 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     }
 
     private HolidayEntity saveHoliday(Holiday holiday) {
-        Long countryId = getCountryIdByHolidayCountry(holiday);
-
-        HolidayEntity holidayEntity = HolidayEntity.fromHoliday(holiday, countryId);
+        HolidayEntity holidayEntity = HolidayEntity.fromHoliday(holiday);
         return holidayJpaRepository.save(holidayEntity);
-    }
-
-    private Long getCountryIdByHolidayCountry(Holiday holiday) {
-        CountryEntity countryEntity = countryJpaRepository.findByCode(holiday.getCountryCode())
-                .orElseThrow(() -> new CountryNotFoundException(
-                        "국가 코드 " + holiday.getCountryCode() + "에 해당하는 국가의 정보를 찾을 수 없습니다."));
-
-        return countryEntity.getCountryId();
     }
 
     private void saveHolidayCounties(Holiday holiday, HolidayEntity savedHolidayEntity) {

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -46,21 +46,21 @@ public class HolidayRepositoryImpl implements HolidayRepository {
 
     @Override
     public List<Holiday> findByYearAndCountryCode(List<Integer> year, List<String> countryCode) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode).orElseThrow();
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearInAndCountryCodeIn(year, countryCode);
 
         return getHolidays(holidayEntities);
     }
 
     @Override
     public List<Holiday> findByYear(List<Integer> year) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year).orElseThrow();
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByYearIn(year);
 
         return getHolidays(holidayEntities);
     }
 
     @Override
     public List<Holiday> findByCountryCodeIn(List<String> countryCode) {
-        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode).orElseThrow();
+        List<HolidayEntity> holidayEntities = holidayJpaRepository.findByCountryCodeIn(countryCode);
 
         return getHolidays(holidayEntities);
     }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayCountyEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayCountyEntity.java
@@ -1,17 +1,22 @@
 package com.publicholidaysbycountry.holiday.infrastructure.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "holiday_county")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class HolidayCountyEntity {
 
     @Id
@@ -20,11 +25,13 @@ public class HolidayCountyEntity {
 
     private String countyName;
 
-    private Long holidayId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "holidayId")
+    private HolidayEntity holiday;
 
     @Builder
-    public HolidayCountyEntity(String countyName, Long holidayId) {
+    public HolidayCountyEntity(String countyName, HolidayEntity holiday) {
         this.countyName = countyName;
-        this.holidayId = holidayId;
+        this.holiday = holiday;
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
@@ -23,7 +23,7 @@ public class HolidayEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long holidayId;
 
-    @Column(nullable = false)
+    @Column(name = "holiday_year", nullable = false)
     private Integer year;
 
     @Column(nullable = false)

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
@@ -24,6 +24,9 @@ public class HolidayEntity {
     private Long holidayId;
 
     @Column(nullable = false)
+    private Integer year;
+
+    @Column(nullable = false)
     private LocalDate date;
 
     @Column(nullable = false)
@@ -33,7 +36,7 @@ public class HolidayEntity {
     private String name;
 
     @Column(nullable = false)
-    private Long countryId;
+    private String countryCode;
 
     @Column(nullable = false)
     private boolean fixed;
@@ -44,28 +47,42 @@ public class HolidayEntity {
     private Integer launchYear;
 
     @Builder
-    public HolidayEntity(Long holidayId, LocalDate date, String localName, String name, Long countryId, boolean fixed,
+    public HolidayEntity(Long holidayId, Integer year, LocalDate date, String localName, String name, String countryCode, boolean fixed,
                          boolean global, Integer launchYear) {
         this.holidayId = holidayId;
+        this.year = year;
         this.date = date;
         this.localName = localName;
         this.name = name;
-        this.countryId = countryId;
+        this.countryCode = countryCode;
         this.fixed = fixed;
         this.global = global;
         this.launchYear = launchYear;
     }
 
-    public static HolidayEntity fromHoliday(Holiday holiday, Long countryId) {
+    public static HolidayEntity fromHoliday(Holiday holiday) {
         return HolidayEntity.builder()
+                .year(holiday.getDate().getYear())
                 .date(holiday.getDate())
                 .localName(holiday.getLocalName())
                 .name(holiday.getName())
-                .countryId(countryId)
+                .countryCode(holiday.getCountryCode())
                 .fixed(holiday.isFixed())
                 .global(holiday.isGlobal())
                 .launchYear(holiday.getLaunchYear())
                 .build();
 
+    }
+
+    public Holiday toHoliday() {
+        return Holiday.builder()
+                .date(this.date)
+                .localName(this.localName)
+                .name(this.name)
+                .countryCode(this.countryCode)
+                .fixed(this.fixed)
+                .global(this.global)
+                .launchYear(this.launchYear)
+                .build();
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
@@ -11,8 +11,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,11 +53,11 @@ public class HolidayEntity {
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "holidayId", referencedColumnName = "holidayId")
-    private List<HolidayCountyEntity> counties;
+    private Set<HolidayCountyEntity> counties;
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "holidayId", referencedColumnName = "holidayId")
-    private List<HolidayTypeEntity> types;
+    private Set<HolidayTypeEntity> types;
 
     @Builder
     public HolidayEntity(Long holidayId, Integer year, LocalDate date, String localName, String name,
@@ -99,14 +99,14 @@ public class HolidayEntity {
                 .launchYear(this.launchYear)
                 .counties(
                         Optional.ofNullable(this.counties)
-                                .orElseGet(List::of)
+                                .orElseGet(Set::of)
                                 .stream()
                                 .map(HolidayCountyEntity::getCountyName)
                                 .toList()
                 )
                 .types(
                         Optional.ofNullable(this.types)
-                                .orElseGet(List::of)
+                                .orElseGet(Set::of)
                                 .stream()
                                 .map(HolidayTypeEntity::getType)
                                 .toList()

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayEntity.java
@@ -3,11 +3,16 @@ package com.publicholidaysbycountry.holiday.infrastructure.entity;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,8 +51,17 @@ public class HolidayEntity {
 
     private Integer launchYear;
 
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "holidayId", referencedColumnName = "holidayId")
+    private List<HolidayCountyEntity> counties;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "holidayId", referencedColumnName = "holidayId")
+    private List<HolidayTypeEntity> types;
+
     @Builder
-    public HolidayEntity(Long holidayId, Integer year, LocalDate date, String localName, String name, String countryCode, boolean fixed,
+    public HolidayEntity(Long holidayId, Integer year, LocalDate date, String localName, String name,
+                         String countryCode, boolean fixed,
                          boolean global, Integer launchYear) {
         this.holidayId = holidayId;
         this.year = year;
@@ -83,6 +97,20 @@ public class HolidayEntity {
                 .fixed(this.fixed)
                 .global(this.global)
                 .launchYear(this.launchYear)
+                .counties(
+                        Optional.ofNullable(this.counties)
+                                .orElseGet(List::of)
+                                .stream()
+                                .map(HolidayCountyEntity::getCountyName)
+                                .toList()
+                )
+                .types(
+                        Optional.ofNullable(this.types)
+                                .orElseGet(List::of)
+                                .stream()
+                                .map(HolidayTypeEntity::getType)
+                                .toList()
+                )
                 .build();
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayTypeEntity.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/entity/HolidayTypeEntity.java
@@ -5,33 +5,39 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "holiday_type")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class HolidayTypeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long holidayTypeId;
 
-    @Column(nullable = false)
-    private Long holidayId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "holidayId")
+    private HolidayEntity holiday;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private HolidayType type;
 
     @Builder
-    public HolidayTypeEntity(Long holidayId, HolidayType type) {
-        this.holidayId = holidayId;
+    public HolidayTypeEntity(HolidayEntity holiday, HolidayType type) {
+        this.holiday = holiday;
         this.type = type;
     }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -10,19 +10,16 @@ import com.publicholidaysbycountry.holiday.presentation.request.YearAndCountryFi
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,7 +44,7 @@ public class HolidayController {
 
     @Operation(summary = "연도별·국가별 필터 기반 공휴일 조회", description = "연도별·국가별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
     @GetMapping
-    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByFilter(
+    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByYearAndCountry(
             @Validated @ModelAttribute YearAndCountryFilterRequest request) {
         List<Integer> year = request.getYear();
         List<String> countryCode = request.getCountryCode();

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -68,10 +68,7 @@ public class HolidayController {
             holidayPage = holidayService.getAllHolidays(pageRequest);
         }
 
-        return CommonApiResponse.success(
-                holidayPage.getContent(),
-                "총 " + holidayPage.getTotalElements() + "개 중 " + holidayPage.getNumberOfElements() + "개의 공휴일이 조회되었습니다."
-        );
+        return getHolidaysCommonApiResponse(holidayPage);
     }
 
     @Operation(summary = "기간별 필터 기반 공휴일 조회", description = "기간별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
@@ -83,6 +80,11 @@ public class HolidayController {
                 request.getFrom(), request.getTo(), pageRequest
         );
 
+        return getHolidaysCommonApiResponse(holidayPage);
+    }
+
+    private CommonApiResponse<List<HolidayResponseDTO>> getHolidaysCommonApiResponse(
+            Page<HolidayResponseDTO> holidayPage) {
         return CommonApiResponse.success(
                 holidayPage.getContent(),
                 "총 " + holidayPage.getTotalElements() + "개 중 " + holidayPage.getNumberOfElements() + "개의 공휴일이 조회되었습니다."

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -6,16 +6,21 @@ import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.global.response.CommonApiResponse;
 import com.publicholidaysbycountry.holiday.application.HolidayInitializationFacade;
 import com.publicholidaysbycountry.holiday.application.HolidayService;
+import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/holidays")
 @Tag(name = "Holiday", description = "Holiday API")
 public class HolidayController {
 
@@ -24,13 +29,43 @@ public class HolidayController {
     private final HolidayInitializationFacade holidayInitializationFacade;
 
     @Operation(summary = "국가별 공휴일 저장", description = "외부 API에서 가져온 국가별 공휴일을 저장합니다.")
-    @PostMapping("/holidays")
+    @PostMapping
     public CommonApiResponse<String> saveHolidaysByCountryAndYear() {
         holidayInitializationFacade.deleteAllHolidaysAndCountries();
         List<Country> countries = countryService.saveCountries();
         int savedHolidayCount = holidayService.saveHolidays(countries, LocalDate.now().getYear());
         return CommonApiResponse.success(
                 "최근 " + Constants.YEAR_RANGE + "년 공휴일 " + savedHolidayCount + "개가 성공적으로 저장되었습니다.");
+    }
+
+    @Operation(summary = "필터 기반 공휴일 조회", description = "연도별·국가별 필터 기반으로 공휴일을 조회합니다.")
+    @GetMapping
+    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByFilter(@RequestParam(required = false) List<Integer> year,
+                                                        @RequestParam(required = false) List<String> countryCode) {
+        boolean hasYear = hasYear(year);
+        boolean hasCountry = HasCountry(countryCode);
+
+        List<HolidayResponseDTO> holidayResponseDTOs;
+
+        if (hasYear && hasCountry) {
+            holidayResponseDTOs = holidayService.getHolidaysByYearAndCountry(year, countryCode);
+        } else if (hasYear) {
+            holidayResponseDTOs = holidayService.getHolidaysByYear(year);
+        } else if (hasCountry) {
+            holidayResponseDTOs = holidayService.getHolidaysByCountry(countryCode);
+        } else {
+            holidayResponseDTOs = holidayService.getAllHolidays();
+        }
+
+        return CommonApiResponse.success(holidayResponseDTOs, "공휴일 " + holidayResponseDTOs.size() + "개가 조회되었습니다.");
+    }
+
+    private boolean hasYear(List<Integer> year) {
+        return year != null && !year.isEmpty();
+    }
+
+    private boolean HasCountry(List<String> countryCode) {
+        return countryCode != null && !countryCode.isEmpty();
     }
 
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -6,15 +6,20 @@ import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.global.response.CommonApiResponse;
 import com.publicholidaysbycountry.holiday.application.HolidayInitializationFacade;
 import com.publicholidaysbycountry.holiday.application.HolidayService;
+import com.publicholidaysbycountry.holiday.presentation.request.YearAndCountryFilterRequest;
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,10 +48,12 @@ public class HolidayController {
     @Operation(summary = "연도별·국가별 필터 기반 공휴일 조회", description = "연도별·국가별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
     @GetMapping
     public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByFilter(
-            @RequestParam(required = false) List<Integer> year,
-            @RequestParam(required = false) List<String> countryCode,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @Validated @ModelAttribute YearAndCountryFilterRequest request) {
+        List<Integer> year = request.getYear();
+        List<String> countryCode = request.getCountryCode();
+        int page = request.getPageOrDefault();
+        int size = request.getSizeOrDefault();
+
         boolean hasYear = hasYear(year);
         boolean hasCountry = hasCountry(countryCode);
 

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -6,7 +6,7 @@ import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.global.response.CommonApiResponse;
 import com.publicholidaysbycountry.holiday.application.HolidayInitializationFacade;
 import com.publicholidaysbycountry.holiday.application.HolidayService;
-import com.publicholidaysbycountry.holiday.presentation.request.DateFilterRequest;
+import com.publicholidaysbycountry.holiday.presentation.request.FilterRequest;
 import com.publicholidaysbycountry.holiday.presentation.request.YearAndCountryFilterRequest;
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,13 +71,15 @@ public class HolidayController {
         return getHolidaysCommonApiResponse(holidayPage);
     }
 
-    @Operation(summary = "기간별 필터 기반 공휴일 조회", description = "기간별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
-    @GetMapping("/date")
-    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByDate(
-            @Validated @ModelAttribute DateFilterRequest request) {
+    @Operation(summary = "필터 기반 공휴일 조회", description = "date, type, county, fixed, global, launchYear, countryCode별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
+    @GetMapping("/filter")
+    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByFilter(
+            @Validated @ModelAttribute FilterRequest request) {
         PageRequest pageRequest = PageRequest.of(request.getPageOrDefault(), request.getSizeOrDefault());
-        Page<HolidayResponseDTO> holidayPage = holidayService.getHolidaysByDate(
-                request.getFrom(), request.getTo(), pageRequest
+
+        Page<HolidayResponseDTO> holidayPage = holidayService.getHolidaysByFilter(
+                request.getFrom(), request.getTo(), request.getType(), request.getHasCounty(), request.getFixed(),
+                request.getGlobal(), request.getLaunchYear(), request.getCountryCode(), pageRequest
         );
 
         return getHolidaysCommonApiResponse(holidayPage);

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/HolidayController.java
@@ -6,6 +6,7 @@ import com.publicholidaysbycountry.global.Constants;
 import com.publicholidaysbycountry.global.response.CommonApiResponse;
 import com.publicholidaysbycountry.holiday.application.HolidayInitializationFacade;
 import com.publicholidaysbycountry.holiday.application.HolidayService;
+import com.publicholidaysbycountry.holiday.presentation.request.DateFilterRequest;
 import com.publicholidaysbycountry.holiday.presentation.request.YearAndCountryFilterRequest;
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -66,6 +67,21 @@ public class HolidayController {
         } else {
             holidayPage = holidayService.getAllHolidays(pageRequest);
         }
+
+        return CommonApiResponse.success(
+                holidayPage.getContent(),
+                "총 " + holidayPage.getTotalElements() + "개 중 " + holidayPage.getNumberOfElements() + "개의 공휴일이 조회되었습니다."
+        );
+    }
+
+    @Operation(summary = "기간별 필터 기반 공휴일 조회", description = "기간별 필터 기반으로 공휴일을 페이징 처리하여 조회합니다.")
+    @GetMapping("/date")
+    public CommonApiResponse<List<HolidayResponseDTO>> getHolidaysByDate(
+            @Validated @ModelAttribute DateFilterRequest request) {
+        PageRequest pageRequest = PageRequest.of(request.getPageOrDefault(), request.getSizeOrDefault());
+        Page<HolidayResponseDTO> holidayPage = holidayService.getHolidaysByDate(
+                request.getFrom(), request.getTo(), pageRequest
+        );
 
         return CommonApiResponse.success(
                 holidayPage.getContent(),

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/DateFilterRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/DateFilterRequest.java
@@ -1,15 +1,16 @@
 package com.publicholidaysbycountry.holiday.presentation.request;
 
-import com.publicholidaysbycountry.global.Constants;
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
-@Data
-public class DateFilterRequest {
+@Getter
+@Setter
+public class DateFilterRequest extends PagingRequest {
+
     @NotNull(message = "시작일(from)은 필수입니다.")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate from;
@@ -18,28 +19,9 @@ public class DateFilterRequest {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate to;
 
-    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
-    private Integer page;
-
-    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
-    private Integer size;
-
     @AssertTrue(message = "시작일(from)은 종료일(to)보다 이후일 수 없습니다.")
     public boolean isValidDateRange() {
         return from == null || to == null || !from.isAfter(to);
     }
 
-    public int getPageOrDefault() {
-        if (page == null || page < 0) {
-            return Constants.DEFAULT_PAGE;
-        }
-        return page;
-    }
-
-    public int getSizeOrDefault() {
-        if (size == null || size < 1) {
-            return 10;
-        }
-        return Constants.DEFAULT_SIZE;
-    }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/DateFilterRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/DateFilterRequest.java
@@ -1,0 +1,45 @@
+package com.publicholidaysbycountry.holiday.presentation.request;
+
+import com.publicholidaysbycountry.global.Constants;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class DateFilterRequest {
+    @NotNull(message = "시작일(from)은 필수입니다.")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate from;
+
+    @NotNull(message = "종료일(to)은 필수입니다.")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate to;
+
+    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+    private Integer page;
+
+    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+    private Integer size;
+
+    @AssertTrue(message = "시작일(from)은 종료일(to)보다 이후일 수 없습니다.")
+    public boolean isValidDateRange() {
+        return from == null || to == null || !from.isAfter(to);
+    }
+
+    public int getPageOrDefault() {
+        if (page == null || page < 0) {
+            return Constants.DEFAULT_PAGE;
+        }
+        return page;
+    }
+
+    public int getSizeOrDefault() {
+        if (size == null || size < 1) {
+            return 10;
+        }
+        return Constants.DEFAULT_SIZE;
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/FilterRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/FilterRequest.java
@@ -1,23 +1,35 @@
 package com.publicholidaysbycountry.holiday.presentation.request;
 
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @Setter
-public class DateFilterRequest extends PagingRequest {
+public class FilterRequest extends PagingRequest {
 
-    @NotNull(message = "시작일(from)은 필수입니다.")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate from;
 
-    @NotNull(message = "종료일(to)은 필수입니다.")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate to;
+
+    private List<String> type;
+
+    private Boolean hasCounty;
+
+    private Boolean fixed;
+
+    private Boolean global;
+
+    @Min(value = 1000, message = "launchYear는 1000 이상이어야 합니다.")
+    private Integer launchYear;
+
+    private List<String> countryCode;
 
     @AssertTrue(message = "시작일(from)은 종료일(to)보다 이후일 수 없습니다.")
     public boolean isValidDateRange() {

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/PagingRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/PagingRequest.java
@@ -1,0 +1,32 @@
+package com.publicholidaysbycountry.holiday.presentation.request;
+
+import com.publicholidaysbycountry.global.Constants;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PagingRequest {
+
+    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+    private Integer page;
+
+    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+    private Integer size;
+
+    public int getPageOrDefault() {
+        if (page == null || page < 0) {
+            return Constants.DEFAULT_PAGE;
+        }
+        return page;
+    }
+
+    public int getSizeOrDefault() {
+        if (size == null || size < 1) {
+            return Constants.DEFAULT_SIZE;
+        }
+        return size;
+    }
+
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/YearAndCountryFilterRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/YearAndCountryFilterRequest.java
@@ -1,0 +1,33 @@
+package com.publicholidaysbycountry.holiday.presentation.request;
+
+import com.publicholidaysbycountry.global.Constants;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class YearAndCountryFilterRequest {
+    private List<@Positive(message = "year는 양수여야 합니다.") Integer> year;
+    private List<String> countryCode;
+
+    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+    private Integer page;
+
+    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+    private Integer size;
+
+    public int getPageOrDefault() {
+        if (page == null || page < 0) {
+            return Constants.DEFAULT_PAGE;
+        }
+        return page;
+    }
+
+    public int getSizeOrDefault() {
+        if (size == null || size < 1) {
+            return 10;
+        }
+        return Constants.DEFAULT_SIZE;
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/YearAndCountryFilterRequest.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/request/YearAndCountryFilterRequest.java
@@ -1,33 +1,16 @@
 package com.publicholidaysbycountry.holiday.presentation.request;
 
-import com.publicholidaysbycountry.global.Constants;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
-public class YearAndCountryFilterRequest {
+@Getter
+@Setter
+public class YearAndCountryFilterRequest extends PagingRequest {
+
     private List<@Positive(message = "year는 양수여야 합니다.") Integer> year;
+
     private List<String> countryCode;
 
-    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
-    private Integer page;
-
-    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
-    private Integer size;
-
-    public int getPageOrDefault() {
-        if (page == null || page < 0) {
-            return Constants.DEFAULT_PAGE;
-        }
-        return page;
-    }
-
-    public int getSizeOrDefault() {
-        if (size == null || size < 1) {
-            return 10;
-        }
-        return Constants.DEFAULT_SIZE;
-    }
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/response/HolidayResponseDTO.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/response/HolidayResponseDTO.java
@@ -1,0 +1,34 @@
+package com.publicholidaysbycountry.holiday.presentation.response;
+
+import com.publicholidaysbycountry.holiday.domain.Holiday;
+import com.publicholidaysbycountry.holiday.domain.HolidayType;
+import java.util.List;
+
+public record HolidayResponseDTO(
+        String date,
+        String localName,
+        String name,
+        String countryCode,
+        boolean fixed,
+        boolean global,
+        List<String> counties,
+        Integer launchYear,
+        List<HolidayType> types
+) {
+
+    public static List<HolidayResponseDTO> fromHolidays(List<Holiday> holidays) {
+        return holidays.stream()
+                .map(holiday -> new HolidayResponseDTO(
+                        holiday.getDate().toString(),
+                        holiday.getLocalName(),
+                        holiday.getName(),
+                        holiday.getCountryCode(),
+                        holiday.isFixed(),
+                        holiday.isGlobal(),
+                        holiday.getCounties(),
+                        holiday.getLaunchYear(),
+                        holiday.getTypes()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/presentation/response/HolidayResponseDTO.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/presentation/response/HolidayResponseDTO.java
@@ -16,19 +16,17 @@ public record HolidayResponseDTO(
         List<HolidayType> types
 ) {
 
-    public static List<HolidayResponseDTO> fromHolidays(List<Holiday> holidays) {
-        return holidays.stream()
-                .map(holiday -> new HolidayResponseDTO(
-                        holiday.getDate().toString(),
-                        holiday.getLocalName(),
-                        holiday.getName(),
-                        holiday.getCountryCode(),
-                        holiday.isFixed(),
-                        holiday.isGlobal(),
-                        holiday.getCounties(),
-                        holiday.getLaunchYear(),
-                        holiday.getTypes()
-                ))
-                .toList();
+    public static HolidayResponseDTO fromHoliday(Holiday holiday) {
+        return new HolidayResponseDTO(
+                holiday.getDate().toString(),
+                holiday.getLocalName(),
+                holiday.getName(),
+                holiday.getCountryCode(),
+                holiday.isFixed(),
+                holiday.isGlobal(),
+                holiday.getCounties(),
+                holiday.getLaunchYear(),
+                holiday.getTypes()
+        );
     }
 }


### PR DESCRIPTION
## 📌 개요
연도별·국가별 필터 기반 공휴일 조회
from ~ to 기간, 공휴일 타입 등 추가 필터 자유 확장
결과는 페이징형태로 응답

## ✅ 변경 사항
- [x] 연도별·국가별 필터 기반 공휴일 조회 기능 추가 
- [x] 필터 기반 공휴일 조회 기능 추가 - 필터 조건: from, to, type, countryCode, hasCounty, fixed, global, launchYear
- [x] QueryDSL 적용
- [x] HolidayEntity 구조 변경 


## 📎 관련 이슈
- closes #7 

