### PR TITLE
refactor: 코드 리팩토링 

### DIFF
--- a/src/main/java/com/publicholidaysbycountry/config/AsyncConfig.java
+++ b/src/main/java/com/publicholidaysbycountry/config/AsyncConfig.java
@@ -1,0 +1,31 @@
+package com.publicholidaysbycountry.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "asyncExecutor")
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("async-thread-");
+        executor.setRejectedExecutionHandler(new CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return asyncExecutor();
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayAsyncService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayAsyncService.java
@@ -1,0 +1,23 @@
+package com.publicholidaysbycountry.holiday.application;
+
+import com.publicholidaysbycountry.country.domain.Country;
+import com.publicholidaysbycountry.holiday.application.dto.HolidayDTO;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HolidayAsyncService {
+
+    private final HolidayApiClient holidayApiClient;
+
+    @Async
+    public CompletableFuture<List<HolidayDTO>> getHolidaysAsync(Country country, int year) {
+        HolidayDTO[] holidayArray = holidayApiClient.getHolidayApiRequest(country, year);
+        return CompletableFuture.completedFuture(Arrays.asList(holidayArray));
+    }
+}

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayRepository.java
@@ -25,4 +25,6 @@ public interface HolidayRepository {
                                   Boolean global, Integer launchYear, List<String> countryCode, Pageable pageable);
 
     int deleteByYearAndCountryCode(Integer year, String code);
+
+    int upsertWithCountiesAndTypes(List<Holiday> newHolidays);
 }

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -6,7 +6,6 @@ import com.publicholidaysbycountry.global.exception.InvalidHolidayTypeException;
 import com.publicholidaysbycountry.holiday.application.dto.HolidayDTO;
 import com.publicholidaysbycountry.holiday.domain.Holiday;
 import com.publicholidaysbycountry.holiday.domain.HolidayType;
-import com.publicholidaysbycountry.holiday.infrastructure.HolidayJdbcRepository;
 import com.publicholidaysbycountry.holiday.presentation.response.HolidayResponseDTO;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ public class HolidayService {
 
     private final HolidayRepository holidayRepository;
     private final HolidayApiClient holidayApiClient;
-    private final HolidayJdbcRepository holidayJdbcRepository;
 
     @Transactional
     public int saveHolidays(List<Country> countries, int currentYear) {
@@ -80,7 +78,7 @@ public class HolidayService {
                 Arrays.asList(holidayApiClient.getHolidayApiRequest(country, year)));
         List<Holiday> newHolidays = HolidayDTO.toHolidays(holidayDTOs);
 
-        return holidayJdbcRepository.upsertWithCountiesAndTypes(newHolidays);
+        return holidayRepository.upsertWithCountiesAndTypes(newHolidays);
     }
 
     @Transactional

--- a/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/application/HolidayService.java
@@ -27,7 +27,7 @@ public class HolidayService {
 
     @Transactional
     public int saveHolidays(List<Country> countries, int currentYear) {
-        List<Holiday> holidays = getHolidaysByCountryAndYear(countries, currentYear);
+        List<Holiday> holidays = getHolidaysFromApiByCountryAndYear(countries, currentYear);
         return holidayRepository.save(holidays);
     }
 
@@ -86,7 +86,7 @@ public class HolidayService {
         return holidayRepository.deleteByYearAndCountryCode(year, country.getCode());
     }
 
-    private List<Holiday> getHolidaysByCountryAndYear(List<Country> countries, int currentYear) {
+    private List<Holiday> getHolidaysFromApiByCountryAndYear(List<Country> countries, int currentYear) {
         Set<HolidayDTO> holidayDTOs = new HashSet<>();
 
         for (Country country : countries) {

--- a/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
+++ b/src/main/java/com/publicholidaysbycountry/holiday/infrastructure/HolidayRepositoryImpl.java
@@ -21,6 +21,7 @@ public class HolidayRepositoryImpl implements HolidayRepository {
     private final HolidayCountyJpaRepository holidayCountyJpaRepository;
     private final HolidayTypeJpaRepository holidayTypeJpaRepository;
     private final HolidayQueryRepository holidayQueryRepository;
+    private final HolidayJdbcRepository holidayJdbcRepository;
 
     @Override
     public int save(List<Holiday> holidays) {
@@ -81,6 +82,11 @@ public class HolidayRepositoryImpl implements HolidayRepository {
         Page<HolidayEntity> holidayEntities = holidayQueryRepository.findAllByFilter(from, to, types, hasCounty, fixed,
                 global, launchYear, countryCode, pageable);
         return holidayEntities.map(HolidayEntity::toHoliday);
+    }
+
+    @Override
+    public int upsertWithCountiesAndTypes(List<Holiday> newHolidays) {
+        return holidayJdbcRepository.upsertWithCountiesAndTypes(newHolidays);
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요
외부 API에서 공휴일 데이터를 받아올 때 시간이 오래 걸리는 문제를 개선
구조 개선 

## ✅ 변경 사항
- [x] 외부 API 병렬 조회를 위한 비동기 처리 도입
- HolidayAsyncService 클래스 생성해서 @Async 메서드로 국가별, 공휴일 비동기 조회
- 공휴일 전체 저장 시간 2분 57초 → 13초로 단축
- 공휴일 데이터를 저장하는 것보다 외부 API에서 데이터를 가져오는 시간이 오래 걸려 도입하게 됨
- [x] holidayJdbcRepository 접근을 HolidayService → HolidayRepository로 이동
- [x] 외부 API에서 공휴일 받아오는 메서드 이름 getHolidaysFromApiByCountryAndYear로 변경 


## 📎 관련 이슈
- closes #18 

